### PR TITLE
Added in CLI option to pass in the version of the API we are looking for

### DIFF
--- a/config-test/conftest.py
+++ b/config-test/conftest.py
@@ -14,8 +14,18 @@ def pytest_addoption(parser):
         default="stage",
         help="Environment tests are running in: stage or prod"
     )
+    parser.addoption(
+        "--api-version",
+        dest="apiversion",
+        help="Version of Kinto API we are testing against"
+    )
 
 
 @pytest.fixture(scope="module")
 def env(request):
     return request.config.getoption("--env")
+
+
+@pytest.fixture(scope="module")
+def apiversion(request):
+    return request.config.getoption("--api-version")

--- a/config-test/test_server_details.py
+++ b/config-test/test_server_details.py
@@ -23,7 +23,7 @@ def api(event_loop, conf, env):
 
 
 @pytest.mark.asyncio
-async def test_version(api):
+async def test_version(api, conf, env, apiversion):
     res = await api.__version__()
     data = await res.json()
     expected_fields = aslist(conf.get(env, 'version_fields'))
@@ -36,9 +36,12 @@ async def test_version(api):
     for field in expected_fields:
         assert field in data
 
+    # Finally check to see if we are getting the version we expect
+    assert apiversion == data['version']
+    
 
 @pytest.mark.asyncio
-async def test_heartbeat(api):
+async def test_heartbeat(api, conf, env):
     res = await api.__heartbeat__()
     data = await res.json()
     expected_fields = aslist(conf.get(env, 'heartbeat_fields'))


### PR DESCRIPTION
r? @Natim 

Figured it would be worth making sure the expected version from the release actually exists, since that info is known before deploymenet