### PR TITLE
Use new shared library testProject method to run tests from Service Book

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,6 @@
 @Library('fxtest@servicebook') _
 
-def sb = new org.mozilla.fxtest.ServiceBook()
-sb.testProject(kinto)
+node {
+    def sb = new org.mozilla.fxtest.ServiceBook()
+    sb.testProject('kinto')
+}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,33 +1,4 @@
-@Library('fxtest@1.6') _
+@Library('fxtest@servicebook')
 
-pipeline {
-  agent any
-  options {
-    ansiColor('xterm')
-    timestamps()
-    timeout(time: 5, unit: 'MINUTES')
-  }
-  environment {
-    PYTEST_ADDOPTS = "-n=10 --color=yes"
-  }
-  stages {
-    stage('Test') {
-      steps {
-        sh "${WORKSPACE}/run"
-      }
-    }
-  }
-  post {
-    failure {
-      mail(
-        body: "${BUILD_URL}",
-        from: "firefox-test-engineering@mozilla.com",
-        replyTo: "firefox-test-engineering@mozilla.com",
-        subject: "Build failed in Jenkins: ${JOB_NAME} #${BUILD_NUMBER}",
-        to: "chartjes@mozilla.com")
-    }
-    changed {
-      ircNotification('#services-test')
-    }
-  }
-}
+def sb = new org.mozilla.fxtest.ServiceBook()
+sb.testProject(kinto)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,4 +2,4 @@
 
 
 def sb = new org.mozilla.fxtest.ServiceBook()
-sb.testProject('kinto')
+sb.testProject('Kinto')

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
-@Library('fxtest@servicebook')
+@Library('fxtest@servicebook') _
 
 def sb = new org.mozilla.fxtest.ServiceBook()
 sb.testProject(kinto)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,4 +2,4 @@
 
 
 def sb = new org.mozilla.fxtest.ServiceBook()
-sb.testProject('Kinto')
+sb.testProject('kinto')

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,5 @@
 @Library('fxtest@servicebook') _
 
-node {
-    def sb = new org.mozilla.fxtest.ServiceBook()
-    sb.testProject('kinto')
-}
+
+def sb = new org.mozilla.fxtest.ServiceBook()
+sb.testProject('kinto')


### PR DESCRIPTION
**This is in tandem with https://github.com/mozilla/fxtest-jenkins-pipeline/pull/23**

@tarekziade @davehunt @chartjes @rpappalax - looking for any and all helpful feedback, here; thanks!  While this is very much a work in progress, it's a decent start, IMHO.

This: calls the new shared library method testProject.

I've removed the pre-existing pipeline stuff for now, just to simplify this case, but we need to discuss and decide what to leave/put back in.