### PR TITLE
Fix library version

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
-@Library('fxtest') _
+@Library('fxtest@1.7') _
 
 
 def sb = new org.mozilla.fxtest.ServiceBook()

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
-@Library('fxtest@servicebook') _
+@Library('fxtest') _
 
 
 def sb = new org.mozilla.fxtest.ServiceBook()


### PR DESCRIPTION
Now that I've cut a 1.7 release[0], post-merge, this fixes Jenkins. 

@davehunt @chartjes @Natim @tarekziade r?

[0] https://github.com/mozilla/fxtest-jenkins-pipeline/releases/tag/1.7