### PR TITLE
Explicitly pull the latest tag and image from Docker Hub, before running

### DIFF
--- a/run
+++ b/run
@@ -6,4 +6,4 @@
 
 IFS="." read -ra array <<< "${JOB_NAME}"
 TEST_ENV=${array[2]}
-docker run -e TEST_ENV=$TEST_ENV firefoxtesteng/kinto-integration-tests:latest
+docker run -e TEST_ENV=$TEST_ENV firefoxtesteng/kinto-integration-tests

--- a/run
+++ b/run
@@ -6,4 +6,5 @@
 
 IFS="." read -ra array <<< "${JOB_NAME}"
 TEST_ENV=${array[2]}
-docker run -e TEST_ENV=$TEST_ENV firefoxtesteng/kinto-integration-tests
+docker pull firefoxtesteng/kinto-integration-tests:latest
+docker run -e TEST_ENV=$TEST_ENV firefoxtesteng/kinto-integration-tests:latest


### PR DESCRIPTION
Always pull from Docker hub, so we can ensure we have the latest (not cached) when we run.

See https://docs.docker.com/engine/reference/commandline/pull/#pull-an-image-by-digest-immutable-identifier

```
Started by user sdonner@mozilla.com
Building remotely on centos7-1-qatest-slave.fxtestpreprod.jenkins.stage.mozaws.net (qatest linux centos7) in workspace /home/jenkins/workspace/kinto.docker
[kinto.docker] $ /bin/sh -xe /tmp/jenkins6224731422430119673.sh
+ docker images
REPOSITORY                                           TAG                 IMAGE ID            CREATED             SIZE
docker.io/sitespeedio/sitespeed.io                   latest              8d324ec48a36        2 weeks ago         1.577 GB
docker.io/firefoxtesteng/kinto-integration-tests     latest              7ea2d6adc5db        5 weeks ago         350.5 MB
docker.io/firefoxtesteng/kinto-webextensions-tests   latest              8b2e620a2343        6 weeks ago         305.2 MB
docker.io/python                                     2.7                 d580babc9209        3 months ago        677.7 MB
docker.io/node                                       4                   37fa20ad808c        4 months ago        655.3 MB
docker.io/golang                                     1.7                 56101cf2abe8        4 months ago        675.6 MB
docker.io/centos                                     6                   30365b2e827c        5 months ago        194.7 MB
docker.io/centos                                     7                   a8493f5f50ff        5 months ago        192.5 MB
docker.io/golang                                     1.6                 63330314bb46        7 months ago        748.5 MB
+ docker pull firefoxtesteng/kinto-integration-tests:latest
Trying to pull repository docker.io/firefoxtesteng/kinto-integration-tests ... 
latest: Pulling from docker.io/firefoxtesteng/kinto-integration-tests
ec37562cf8fa: Already exists
97b781953675: Already exists
e0147ce9bb75: Pulling fs layer
07831941f8a2: Pulling fs layer
e62b806fc85f: Pulling fs layer
e62b806fc85f: Verifying Checksum
e62b806fc85f: Download complete
07831941f8a2: Verifying Checksum
07831941f8a2: Download complete
e0147ce9bb75: Verifying Checksum
e0147ce9bb75: Download complete
e0147ce9bb75: Pull complete
07831941f8a2: Pull complete
e62b806fc85f: Pull complete
Digest: sha256:d25633b498bb4c3ccb277ef59f1880617fca7e324ec084d5bd269c17eba115ae
+ docker images
REPOSITORY                                           TAG                 IMAGE ID            CREATED             SIZE
docker.io/firefoxtesteng/kinto-integration-tests     latest              28884c9f4d44        3 hours ago         434.5 MB
docker.io/sitespeedio/sitespeed.io                   latest              8d324ec48a36        2 weeks ago         1.577 GB
docker.io/firefoxtesteng/kinto-integration-tests     <none>              7ea2d6adc5db        5 weeks ago         350.5 MB
docker.io/firefoxtesteng/kinto-webextensions-tests   latest              8b2e620a2343        6 weeks ago         305.2 MB
docker.io/python                                     2.7                 d580babc9209        3 months ago        677.7 MB
docker.io/node                                       4                   37fa20ad808c        4 months ago        655.3 MB
docker.io/golang                                     1.7                 56101cf2abe8        4 months ago        675.6 MB
docker.io/centos                                     6                   30365b2e827c        5 months ago        194.7 MB
docker.io/centos                                     7                   a8493f5f50ff        5 months ago        192.5 MB
docker.io/golang                                     1.6                 63330314bb46        7 months ago        748.5 MB
Finished: SUCCESS
```