### PR TITLE
Fix run file by using 2nd string in Jenkins' job name

### DIFF
--- a/run
+++ b/run
@@ -1,10 +1,10 @@
 #!/bin/bash
 
-# project.test_type.test_env
+# project.test_env
 # ${JOB_NAME} is a Jenkins var
 
 
 IFS="." read -ra array <<< "${JOB_NAME}"
-TEST_ENV=${array[2]}
+TEST_ENV=${array[1]}
 docker pull firefoxtesteng/kinto-integration-tests:latest
 docker run -e TEST_ENV=$TEST_ENV firefoxtesteng/kinto-integration-tests:latest


### PR DESCRIPTION
@rpappalax r?

This got me a lot farther, now that https://github.com/Kinto/kinto-integration-tests/pull/41 is merged, and we're using the correct API URL via the v1.9 of the shared library:

https://qa-preprod-master.fxtest.jenkins.stage.mozaws.net/job/kinto.stage/16/console