### PR TITLE
Fix env names

### DIFF
--- a/manifest.ini
+++ b/manifest.ini
@@ -12,7 +12,7 @@ fingerprinting-defenses-preview = https://kinto.stage.mozaws.net/v1/buckets/fing
 cdn = https://d1wakkpts9xafo.cloudfront.net
 
 
-[settings-prod]
+[prod]
 reader_server = https://firefox.settings.services.mozilla.com/v1/
 writer_server = https://firefox.settings.services.mozilla.com/v1/
 api_definition = https://firefox.settings.services.mozilla.com/v1/__api__
@@ -34,4 +34,3 @@ server_info_fields = url project_docs project_name capabilities project_version 
 contribute_fields = keywords participate repository description urls name
 font_collection = https://kinto.stage.mozaws.net/v1/buckets/fennec/collections/catalog/records
 cdn = https://d1wakkpts9xafo.cloudfront.net
-

--- a/manifest.ini
+++ b/manifest.ini
@@ -1,4 +1,4 @@
-[stage]
+[dev]
 reader_server = https://kinto.stage.mozaws.net/v1
 writer_server = https://kinto-writer.stage.mozaws.net/v1
 api_definition = https://kinto.stage.mozaws.net/v1/__api__
@@ -24,7 +24,7 @@ font_collection = https://firefox.settings.services.mozilla.com/v1/buckets/fenne
 cdn = https://fennec-catalog.cdn.mozilla.net
 
 
-[settings-stage]
+[stage]
 reader_server = https://settings.stage.mozaws.net/v1/
 writer_server = https://kinto-writer.stage.mozaws.net/v1
 api_definition = https://settings.stage.mozaws.net/v1/__api__


### PR DESCRIPTION
This will match us up with https://github.com/mozilla-services/cloudops-deployment/blob/a435c607afe20310f02677fd39b6a63a2865ec87/projects/kinto/pipeline.groovy#L100-L110 and https://github.com/mozilla-services/cloudops-deployment/blob/a435c607afe20310f02677fd39b6a63a2865ec87/projects/kinto/pipeline.groovy#L55-L66

(And fit the now-conventional https://github.com/Kinto/kinto-integration-tests/blob/1c3ff24fdb7eadef5f81e202594974abc796e54a/run#L3-L8

@rpappalax / @chartjes r?