### PR TITLE
Fix README to match TEST_ENV name tweaks for Jenkins

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,11 +23,11 @@ These are the minimum requirements:
 
 #### Running The Tests
 
-Tests are run using tox. First, we need to set an environment variable called TEST_ENV to be the environment we want our tests to run under. Check the documentation for your shell to determine how to do so. 
+Tests are run using tox. First, we need to set an environment variable called TEST_ENV to be the environment we want our tests to run under. Check the documentation for your shell to determine how to do so.
 
+* dev
+* prod
 * stage
-* settings-prod
-* settings-stage
 
 These match the environments listed in our _manifest.ini_ file.
 


### PR DESCRIPTION
@chartjes @rpappalax r?  Apologies for missing this; really should have noticed and included this, along with https://github.com/Kinto/kinto-integration-tests/pull/44