### PR TITLE
Use a Jenkins declarative pipeline with Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM python:alpine
-RUN apk add --update make gcc git python3-dev musl-dev libffi-dev openssl-dev
+RUN apk add --update make gcc git python3-dev musl-dev libffi-dev openssl openssl-dev
 WORKDIR /app
 RUN pip install pipenv
 COPY Pipfile Pipfile.lock /app/

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,38 @@
-@Library('fxtest@1.9') _
-
-
-def sb = new org.mozilla.fxtest.ServiceBook()
-sb.testProject('kinto')
+pipeline {
+  agent {
+    dockerfile true
+  }
+  libraries {
+    lib('fxtest@1.9')
+  }
+  options {
+    ansiColor('xterm')
+    timestamps()
+    timeout(time: 1, unit: 'HOURS')
+  }
+  stages {
+    stage('Lint') {
+      steps {
+        sh "flake8"
+      }
+    }
+    stage('Test') {
+      steps {
+        sh "pytest --env=${env.TEST_ENV} config-test/"
+      }
+    }
+  }
+  post {
+    failure {
+      emailext(
+        attachLog: true,
+        body: '$BUILD_URL\n\n$FAILED_TESTS',
+        replyTo: '$DEFAULT_REPLYTO',
+        subject: '$DEFAULT_SUBJECT',
+        to: '$DEFAULT_RECIPIENTS')
+    }
+    changed {
+      ircNotification()
+    }
+  }
+}


### PR DESCRIPTION
In this patch I have changed the Jenkins pipeline from scripted to declarative. In doing so I have removed the dependency on ServiceBook. This means that if there were multiple pipelines associated with the Kinto project on ServiceBook, they would not be cloned or executed. As there is only one pipeline associated with Kinto, I felt that this was at least acceptable for demonstration purposes, and perhaps ServiceBook integration is not necessary here.

I have also removed the dependency on Docker Hub by having Jenkins build and run a custom image based on the Dockerfile. This means we would no longer need to maintain this image, and we reduce the external dependencies.

You can see the first build from these changes executed on our preprod Jenkins here: https://qa-preprod-master.fxtest.jenkins.stage.mozaws.net/job/kinto.stage.davehunt/9/, where the initial agent setup (Docker build) caused the build to take just over 2 minutes. The following build at https://qa-preprod-master.fxtest.jenkins.stage.mozaws.net/job/kinto.stage.davehunt/10/ took just 15 seconds. Note that much of this saving is due to the recent removal of tox, so dependencies are now included in the Docker image. 

Additional benefits of using declarative pipelines include ease of reporting results to IRC, Treeherder, and ActiveData if desired.