### PR TITLE
Run the main entry script within a Docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM python:alpine
-RUN apk add --update make gcc git python3-dev musl-dev libffi-dev openssl-dev
+RUN apk add --update bash make gcc git python3-dev musl-dev libffi-dev openssl openssl-dev
 WORKDIR /app
 RUN pip install pipenv
 COPY Pipfile Pipfile.lock /app/

--- a/run
+++ b/run
@@ -6,5 +6,5 @@
 
 IFS="." read -ra array <<< "${JOB_NAME}"
 TEST_ENV=${array[1]}
-docker pull firefoxtesteng/kinto-integration-tests:latest
-docker run --rm -e TEST_ENV=$TEST_ENV firefoxtesteng/kinto-integration-tests:latest
+flake8
+pytest --env=${TEST_ENV} config-test/


### PR DESCRIPTION
**DO NOT MERGE - This pull request is for demonstration and not intended for review/merge.**

In this patch I have changed the run script executed by the ServiceBook shared library function to execute flake8 and pytest directly. This change requires something like https://github.com/mozilla/fxtest-jenkins-pipeline/pull/39 to land in the shared library. An example of a build using this approach can be found here: https://qa-preprod-master.fxtest.jenkins.stage.mozaws.net/job/kinto.stage/44/, however the run time is not typical due to the image being created for the first time. The following build at https://qa-preprod-master.fxtest.jenkins.stage.mozaws.net/job/kinto.stage/45/ is much more realistic for the majority of builds.