### PR TITLE
Add flake8 via Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: python
+python:
+  - 3.6
+install:
+  - pip install flake8
+script:
+  - flake8 .
+notifications:
+  email: fte-ci@mozilla.com


### PR DESCRIPTION
@chartjes r?

The Kinto org is on Travis, so should be easy to hook this up from that side: https://travis-ci.org/Kinto