### PR TITLE
Use PROJECT and TEST_ENV environment variables if they exist

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,8 +6,8 @@ pipeline {
     lib('fxtest@1.9')
   }
   environment {
-    PROJECT = "${JOB_NAME.split('\\.')[0]}"
-    TEST_ENV = "${JOB_NAME.split('\\.')[1]}"
+    PROJECT = "${PROJECT ?: JOB_NAME.split('\\.')[0]}"
+    TEST_ENV = "${TEST_ENV ?: JOB_NAME.split('\\.')[1]}"
   }
   options {
     ansiColor('xterm')


### PR DESCRIPTION
This allowed me to create a kinto.adhoc build on preprod, which prompts for PROJECT, TEST_ENV, REPOSITORY, and BRANCH. This kind of job can be very useful for testing pull requests in Jenkins before we merge them or experimenting with development branches.