### PR TITLE
Remove unused Docker Compose file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,0 @@
-master:
-  image: kinto/kinto-server
-  ports:
-   - "8888:8888"
-read-only:
-  image: chartjes/kinto-read-only
-  ports:
-   - "8889:8889"


### PR DESCRIPTION
@chartjes r?

In the meeting, we noted we might come back to using this, or others like it, at some point, but I'm pretty sure this is unused, for now - the last push to https://hub.docker.com/r/chartjes/kinto-read-only/ was 2 years ago.

Passing ad-hoc build: https://qa-preprod-master.fxtest.jenkins.stage.mozaws.net/job/kinto.adhoc/12/console