### PR TITLE
Add test for blocklist.xml timestamp

### DIFF
--- a/config-tests/test_kinto_signer.py
+++ b/config-tests/test_kinto_signer.py
@@ -1,3 +1,6 @@
+import datetime
+from xml.dom import minidom
+
 import configparser
 import pytest
 import requests
@@ -160,14 +163,25 @@ def test_blocklist_timestamp(env, conf):
             last_modified = max(last_modified, records[0]['last_modified'])
 
     # Read the current XML blocklist ETag.
-    blocklist_uri = conf.get(env, 'reader_server') + (
-        'blocklist/3/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/58.0'
+    blocklist_uri = conf.get(env, 'reader_server').strip('/') + (
+        '/blocklist/3/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/58.0'
         '/Firefox/20180123185941/Darwin_x86_64-gcc3-u-i386-x86_64'
         '/en-US/release/Darwin 17.4.0/default/default/invalid/invalid/0/')
     r = requests.get(blocklist_uri)
     r.raise_for_status()
-    xml_last_modified = int(r.headers.get('ETag', '')[1:-1])
+    etag_header = int(r.headers.get('ETag', '')[1:-1])
+    last_modified_header = r.headers.get('Last-Modified', '')
+    last_modified_header = datetime.datetime.strptime(last_modified_header,
+                                                      '%a, %d %b %Y %H:%M:%S GMT')
 
-    # Make sure they match.
+    # Check XML attribute <blocklist lastupdate="1483471392954">
+    dom = minidom.parseString(r.text)
+    root = dom.getElementsByTagName('blocklist')[0]
+    last_modified_attr = int(root.getAttribute('lastupdate'))
+
+    # Make sure they all match.
     # See https://bugzilla.mozilla.org/show_bug.cgi?id=1436469
-    assert last_modified == xml_last_modified
+    assert last_modified == etag_header
+    last_modified_dt = datetime.datetime.utcfromtimestamp(last_modified / 1000.0)
+    assert last_modified_dt.replace(microsecond=0) == last_modified_header
+    assert last_modified == last_modified_attr

--- a/config-tests/test_kinto_signer.py
+++ b/config-tests/test_kinto_signer.py
@@ -1,5 +1,6 @@
 import configparser
 import pytest
+import requests
 from kinto_signer.serializer import canonical_json
 from kinto_signer.signer.local_ecdsa import ECDSASigner
 from kinto_http import Client, KintoException
@@ -141,3 +142,32 @@ def test_certificate_pinning_signatures(env, conf):
         if e.response.status_code == 401:
             pytest.fail('pinning/pins does not exist')
         pytest.fail('Something went wrong: %s %s' % (e.response.status_code, e.response))
+
+
+@pytestrail.case('C122566')
+@pytest.mark.settings
+def test_blocklist_timestamp(env, conf):
+    client = Client(
+        server_url=conf.get(env, 'reader_server'),
+        bucket='blocklists'
+    )
+    # Take the highest timestamp of the collections contained in the blocklist.xml.
+    last_modified = -1
+    for cid in ('addons', 'plugins', 'gfx'):
+        records = client.get_records(collection=cid, _sort='-last_modified',
+                                     _limit=1, enabled='true')
+        if len(records) > 0:
+            last_modified = max(last_modified, records[0]['last_modified'])
+
+    # Read the current XML blocklist ETag.
+    blocklist_uri = conf.get(env, 'reader_server') + (
+        'blocklist/3/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/58.0'
+        '/Firefox/20180123185941/Darwin_x86_64-gcc3-u-i386-x86_64'
+        '/en-US/release/Darwin 17.4.0/default/default/invalid/invalid/0/')
+    r = requests.get(blocklist_uri)
+    r.raise_for_status()
+    xml_last_modified = int(r.headers.get('ETag', '')[1:-1])
+
+    # Make sure they match.
+    # See https://bugzilla.mozilla.org/show_bug.cgi?id=1436469
+    assert last_modified == xml_last_modified


### PR DESCRIPTION
/cc @gijsk 

Ref https://github.com/mozilla/PollBot/issues/190

**Stage test pass**
```
$ pytest -m settings --env=stage
============================================== test session starts ===============================================
platform linux -- Python 3.6.3, pytest-3.4.0, py-1.5.2, pluggy-0.6.0
rootdir: /home/mathieu/Code/Mozilla/kinto-integration-tests, inifile:
plugins: testrail-1.1.2, asyncio-0.8.0
collected 14 items                                                                                               

config-tests/test_dlc.py ...                                                                               [ 23%]
config-tests/test_kinto_signer.py ....s.                                                                   [ 69%]
config-tests/test_server_details.py ....                                                                   [100%]

=============================================== 1 tests deselected ===============================================
============================== 12 passed, 1 skipped, 1 deselected in 18.20 seconds ===============================
```

**Prod test fails**
```
$ pytest -m settings --env=prod
============================================== test session starts ===============================================
platform linux -- Python 3.6.3, pytest-3.4.0, py-1.5.2, pluggy-0.6.0
rootdir: /home/mathieu/Code/Mozilla/kinto-integration-tests, inifile:
plugins: testrail-1.1.2, asyncio-0.8.0
collected 14 items                                                                                               

config-tests/test_dlc.py ...                                                                               [ 23%]
config-tests/test_kinto_signer.py ....sF                                                                   [ 69%]
config-tests/test_server_details.py ....                                                                   [100%]

==================================================== FAILURES ====================================================
____________________________________________ test_blocklist_timestamp ____________________________________________

env = 'prod', conf = <configparser.ConfigParser object at 0x7f033fd65588>

    @pytestrail.case('C122566')
    @pytest.mark.settings
    def test_blocklist_timestamp(env, conf):
        client = Client(
            server_url=conf.get(env, 'reader_server'),
            bucket='blocklists'
        )
        last_modified = 0
        for cid in ('addons', 'plugins', 'gfx'):
            records = client.get_records(collection=cid, _sort='-last_modified', _limit=1, enabled='true')
            if len(records) > 0:
                last_modified = max(last_modified, records[0]['last_modified'])
    
        blocklist_uri = conf.get(env, 'reader_server') + (
            'blocklist/3/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/58.0'
            '/Firefox/20180123185941/Darwin_x86_64-gcc3-u-i386-x86_64'
            '/en-US/release/Darwin 17.4.0/default/default/invalid/invalid/0/')
        r = requests.get(blocklist_uri)
        r.raise_for_status()
        xml_last_modified = int(r.headers.get('ETag', '')[1:-1])
>       assert last_modified == xml_last_modified
E       assert 1517910100624 == 1483471392954

config-tests/test_kinto_signer.py:167: AssertionError
=============================================== 1 tests deselected ===============================================
========================== 1 failed, 11 passed, 1 skipped, 1 deselected in 8.95 seconds ==========================


```