### PR TITLE
Fix Jenkins build by removing stray comma

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,7 +8,7 @@ pipeline {
   environment {
     PROJECT = "${PROJECT ?: JOB_NAME.split('\\.')[0]}"
     TEST_ENV = "${TEST_ENV ?: JOB_NAME.split('\\.')[1]}"
-    KINTO_QA = credentials('kintoqa'),
+    KINTO_QA = credentials('kintoqa')
     KINTO_DOTENV = credentials('KINTO_DOTENV')
   }
   triggers {


### PR DESCRIPTION
@chartjes r?

This fixes the following failure:

```
Started by an SCM change
Checking out git https://github.com/Kinto/kinto-integration-tests.git into /var/lib/jenkins/workspace/kinto.prod@script to read Jenkinsfile
Wiping out workspace first.
Cloning the remote Git repository
Cloning repository https://github.com/Kinto/kinto-integration-tests.git
 > git init /var/lib/jenkins/workspace/kinto.prod@script # timeout=10
Fetching upstream changes from https://github.com/Kinto/kinto-integration-tests.git
 > git --version # timeout=10
 > git fetch --tags --progress https://github.com/Kinto/kinto-integration-tests.git +refs/heads/*:refs/remotes/origin/*
 > git config remote.origin.url https://github.com/Kinto/kinto-integration-tests.git # timeout=10
 > git config --add remote.origin.fetch +refs/heads/*:refs/remotes/origin/* # timeout=10
 > git config remote.origin.url https://github.com/Kinto/kinto-integration-tests.git # timeout=10
Fetching upstream changes from https://github.com/Kinto/kinto-integration-tests.git
 > git fetch --tags --progress https://github.com/Kinto/kinto-integration-tests.git +refs/heads/*:refs/remotes/origin/*
 > git rev-parse origin/master^{commit} # timeout=10
Checking out Revision bf1f297109ca7337992943712b53daa2d9bdc444 (origin/master)
 > git config core.sparsecheckout # timeout=10
 > git checkout -f bf1f297109ca7337992943712b53daa2d9bdc444
Commit message: "Merge pull request #96 from Kinto/ch-remote-settings"
 > git rev-list ad8a4730a0ae7515b75a5e1047318e47d6756af8 # timeout=10
Running in Durability level: MAX_SURVIVABILITY
org.codehaus.groovy.control.MultipleCompilationErrorsException: startup failed:
WorkflowScript: 11: expecting '}', found ',' @ line 11, column 38.
       KINTO_QA = credentials('kintoqa'),
                                        ^
```