### PR TITLE
Update pypi URL to the new one

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -1,6 +1,6 @@
 [[source]]
 
-url = "https://pypi.python.org/simple"
+url = "https://pypi.org/simple"
 verify_ssl = true
 name = "pypi"
 
@@ -20,4 +20,3 @@ flake8 = "==3.5.0"
 
 
 [dev-packages]
-


### PR DESCRIPTION
Passing ad-hoc here: https://qa-preprod-master.fxtest.jenkins.stage.mozaws.net/job/kinto.adhoc/145/console

@davehunt @chartjes r?