### PR TITLE
Updating remote settings tests to use different account settings

### DIFF
--- a/config-tests/test_remote_settings.py
+++ b/config-tests/test_remote_settings.py
@@ -24,14 +24,14 @@ def test_create_collection_in_main_bucket(conf, env):
     # Allow the refresh signature lambda to write to this collection too.
 
     changes = JSONPatch(
-        [dict(op="add", path="/data/members/0", value="ldap:{0}".format(os.getenv("RS_USER_2_LOGIN")))],
+        [dict(op="add", path="/data/members/0", value="account:{0}".format(os.getenv("RS_USER_2_LOGIN")))],
     )
     client.patch_group(
         id="{0}-reviewers".format(collection),
         changes=changes
     )
     changes = JSONPatch(
-        [dict(op="add", path="/data/members/0", value="ldap:cloudservices_kinto_prod")],
+        [dict(op="add", path="/data/members/0", value="account:cloudservices_kinto_prod")],
     )
     client.patch_group(
         id="{0}-reviewers".format(collection),


### PR DESCRIPTION
Changes test to use account:xxxxx instead of ldap:xxxxx when building the request to approve changes