### PR TITLE
Remove --skip-lock, since we've moved to Dependabot, from pyup.io

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,6 @@ RUN apk add --update make gcc python3-dev musl-dev libffi-dev openssl openssl-de
 WORKDIR /app
 COPY Pipfile pipenv.txt /app/
 RUN pip install -r pipenv.txt
-RUN pipenv install --system --skip-lock
+RUN pipenv install --system
 COPY . /app
 CMD pytest --env=$TEST_ENV

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ RUN apk add --update make gcc python3-dev musl-dev libffi-dev openssl openssl-de
 WORKDIR /app
 COPY Pipfile pipenv.txt /app/
 RUN pip install -r pipenv.txt
-RUN pipenv install --system
+RUN pipenv install
+RUN pipenv lock
 COPY . /app
 CMD pytest --env=$TEST_ENV


### PR DESCRIPTION
This is bombing out for good reason(s), so I'll return to hopefully fixing soon.