### PR TITLE
Revert "Remove --skip-lock, since we've moved to Dependabot, from pyup.io"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,6 @@ RUN apk add --update make gcc python3-dev musl-dev libffi-dev openssl openssl-de
 WORKDIR /app
 COPY Pipfile pipenv.txt /app/
 RUN pip install -r pipenv.txt
-RUN pipenv install
-RUN pipenv lock
+RUN pipenv install --system --skip-lock
 COPY . /app
 CMD pytest --env=$TEST_ENV


### PR DESCRIPTION
@chartjes r, please?  Let's take this to fix the bustage, and we can confer on the best way forward with ```pipenv```, here.

Reverts Kinto/kinto-integration-tests#131