### PR TITLE
Install g++ inside the Docker container.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM python:alpine
-RUN apk add --update make gcc python3-dev musl-dev libffi-dev openssl openssl-dev
+RUN apk add --update make gcc g++ python3-dev musl-dev libffi-dev openssl openssl-dev
 WORKDIR /app
 COPY Pipfile pipenv.txt /app/
 RUN pip install -r pipenv.txt


### PR DESCRIPTION
Some of the version bumps apparently resulted in g++ now being needed, so the container stopped building.

@chartjes Can you please take a look?